### PR TITLE
Sending IP address from API routes

### DIFF
--- a/src/Traits/Visitable.php
+++ b/src/Traits/Visitable.php
@@ -12,10 +12,15 @@ trait Visitable
      * (Registers unique visitors)
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function visit()
+    public function visit($ip)
     {
+        if(isset($ip)){
+            $ip = $ip;
+        } else{
+            $ip = request()->ip();
+        }
         return Visit::firstOrCreate([
-            'ip' => request()->ip(),
+            'ip' => $ip,
             'date' => Carbon::now()->toDateString(),
 
             'visitable_id' => $this->id,


### PR DESCRIPTION
Send IP address from API routes by sending the IP address as parameter:
$post->visit('192.168.1.1');